### PR TITLE
fix: Changed docker image to include user and tag

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-docker run -d --name icloudpd-web -p 5000:5000 -v /path/to/icloudpd-web:/app icloudpd-web
+docker run -d --name icloudpd-web -p 5000:5000 -v /path/to/icloudpd-web:/app spicadust/icloudpd-web:latest
 ```
 
 ## Environment Variables


### PR DESCRIPTION
The docker image is currently released under spicadust/icloudpd-web and not icloudpd-web exclusively. This leads to the command not working when not using the image name togeth with the username.